### PR TITLE
PICkit detection issue

### DIFF
--- a/pk2cmd/pk2cmd.cpp
+++ b/pk2cmd/pk2cmd.cpp
@@ -285,6 +285,10 @@
 // Feature: Support writing packed .hex files (omit blank data). Use -gu to export
 //          unpacked .hex files as before
 // Feature: Support PIC24/33 devices with auxiliary flash memory
+//
+// version 1.27.01 - 23 Jun 2025 tnurse18
+// Bug Fix: Fix PICkit detection issues by correcting a logic error in usbhidioc.cpp
+
 
 
 #include "stdafx.h"

--- a/pk2cmd/stdafx.h
+++ b/pk2cmd/stdafx.h
@@ -7,7 +7,7 @@
 
 #define	VERSION_MAJOR	1
 #define	VERSION_MINOR	27
-#define	VERSION_DOT	0
+#define	VERSION_DOT	1
 
 // #define OLDSTYLE_MSB1ST_SETADDR		// If defined, use the old version of set address scipt for MSB1st families
 									// Has limitation of 128 kB FLASH for PIC18F devices (no bigger devices

--- a/pk2cmd/usbhidioc.cpp
+++ b/pk2cmd/usbhidioc.cpp
@@ -362,11 +362,12 @@ bool CUsbhidioc::FindTheHID(int unitNumber)
 				//Free the memory used by the detailData structure (no longer needed).
 				free(detailData);
 				}  //if (Result != 0)
-
-				else
-					//SetupDiEnumDeviceInterfaces returned 0, so there are no more devices to check.
-					LastDevice=TRUE;
 			}
+		}
+		else
+		{
+			//SetupDiEnumDeviceInterfaces returned 0, so there are no more devices to check.
+			LastDevice = TRUE;
 		}
 
 		//If we haven't found the device yet, and haven't tried every available device,


### PR DESCRIPTION
There appears to be a small bug that can prevent a PICkit from being detected in some rare cases. I was able to verify that the PICkit was connected properly using the Windows Device Manager and [pykitinfo](https://github.com/microchip-pic-avr-tools/pykitinfo), but when running any current version of pk2cmd, it would always return `No PICkit 2, 3 or PKOB found`.

Digging into this a bit further, it seems the issue is right around [line 368 in usbhidioc.cpp](https://github.com/jaka-fi/pk2cmd/blob/34ef4fb3357d933454859120b4490435de10b138/pk2cmd/usbhidioc.cpp#L368). As the comment in the code suggests, `LastDevice` should be set to true when SetupDiEnumDeviceInterfaces returns 0 (indicating that there are no more devices to check). However, this is not what the code currently does. Instead it sets `LastDevice` to true if HidD_GetAttributes returns 0. Evidently, the else block is in the wrong place.

Moving the else block to the correct location seems to resolve these detection issues.